### PR TITLE
Fix release workflow for plugin validator

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-
       - name: Cache node_modules
         id: cache-node-modules
         uses: actions/cache@v2
@@ -43,13 +42,11 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.node-version }}-nodemodules-
-
       - name: Install dependencies
         run: yarn install --frozen-lockfile;
         if: |
           steps.cache-yarn-cache.outputs.cache-hit != 'true' ||
           steps.cache-node-modules.outputs.cache-hit != 'true'
-
       - name: Build and test frontend
         run: yarn build
 
@@ -60,7 +57,6 @@ jobs:
           then
             echo "::set-output name=has-backend::true"
           fi
-
       - name: Test backend
         if: steps.check-for-backend.outputs.has-backend == 'true'
         uses: magefile/mage-action@v1
@@ -95,13 +91,11 @@ jobs:
           echo "::set-output name=archive::${GRAFANA_PLUGIN_ARTIFACT}"
           echo "::set-output name=archive-checksum::${GRAFANA_PLUGIN_ARTIFACT_CHECKSUM}"
           echo ::set-output name=github-tag::${GITHUB_REF#refs/*/}
-
       - name: Read changelog
         id: changelog
         run: |
           awk '/^## / {s++} s == 1 {print}' CHANGELOG.md > release_notes.md
           echo "::set-output name=path::release_notes.md"
-
       - name: Check package version
         run: if [ "v${{ steps.metadata.outputs.plugin-version }}" != "${{ steps.metadata.outputs.github-tag }}" ]; then printf "\033[0;31mPlugin version doesn't match tag name\033[0m\n"; exit 1; fi
 
@@ -112,7 +106,6 @@ jobs:
           zip ${{ steps.metadata.outputs.archive }} ${{ steps.metadata.outputs.plugin-id }} -r
           md5sum ${{ steps.metadata.outputs.archive }} > ${{ steps.metadata.outputs.archive-checksum }}
           echo "::set-output name=checksum::$(cat ./${{ steps.metadata.outputs.archive-checksum }} | cut -d' ' -f1)"
-
       - name: Lint plugin
         run: |
           git clone https://github.com/grafana/plugin-validator
@@ -120,7 +113,6 @@ jobs:
           go install
           popd
           plugincheck ${{ steps.metadata.outputs.archive }}
-
       - name: Create release
         id: create_release
         uses: actions/create-release@v1
@@ -128,7 +120,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref }}
           body_path: ${{ steps.changelog.outputs.path }}
           draft: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
       - name: Lint plugin
         run: |
           git clone https://github.com/grafana/plugin-validator
-          pushd ./plugin-validator/cmd/plugincheck
+          pushd ./plugin-validator/pkg/cmd/plugincheck
           go install
           popd
           plugincheck ${{ steps.metadata.outputs.archive }}


### PR DESCRIPTION
A path in the plugin validator project changed from cmd to pkg/cmd, causing releases to fail.

Using the latest version from https://github.com/grafana/plugin-workflows/blob/master/release.yml now.

Signed-off-by: Natalie Serrino <nserrino@pixielabs.ai>