### PR TITLE
Remove unnecessary conversion to map with scripts.

### DIFF
--- a/src/pxl_scripts.tsx
+++ b/src/pxl_scripts.tsx
@@ -16,6 +16,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { SelectableValue } from '@grafana/data';
+
 const customQuery = require('./pxl_scripts/custom-query.json');
 const exampleQuery = require('pxl_scripts/example-query.json');
 const httpDataFiltered = require('pxl_scripts/http-data-filtered.json');
@@ -30,11 +32,9 @@ interface Script {
 // Load predefined scripts
 const scriptsRaw: Script[] = [customQuery, exampleQuery, httpDataFiltered, httpErrorsPerService];
 
-// Make a map for easier access of scripts
-export const scripts: Map<string, Script> = new Map(scriptsRaw.map((script) => [script.name, script]));
-
 // Construct options list which is injested by Select component in
-export const scriptOptions = scriptsRaw.map((script: Script) => ({
-  label: script.name,
-  description: script.description,
+export const scriptOptions: Array<SelectableValue<string>> = scriptsRaw.map((scriptObject: Script) => ({
+  label: scriptObject.name,
+  description: scriptObject.description,
+  value: scriptObject.script,
 }));

--- a/src/query_editor.tsx
+++ b/src/query_editor.tsx
@@ -22,7 +22,7 @@ import React, { ChangeEvent, PureComponent } from 'react';
 import { TextArea, Select } from '@grafana/ui';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { DataSource } from './datasource';
-import { scriptOptions, scripts } from 'pxl_scripts';
+import { scriptOptions } from 'pxl_scripts';
 import { defaultQuery, PixieDataSourceOptions, PixieDataQuery } from './types';
 
 type Props = QueryEditorProps<DataSource, PixieDataQuery, PixieDataSourceOptions>;
@@ -34,16 +34,11 @@ export class QueryEditor extends PureComponent<Props> {
     onRunQuery();
   }
 
-  onScriptSelect(option: SelectableValue<number>) {
-    if (option.label != null) {
-      // Load in predefined scripts to the script text box
-
-      const script = scripts.get(option.label);
-      if (script !== undefined) {
-        const { onChange, query, onRunQuery } = this.props;
-        onChange({ ...query, pxlScript: script.script });
-        onRunQuery();
-      }
+  onScriptSelect(option: SelectableValue<string>) {
+    if (option.value !== undefined) {
+      const { onChange, query, onRunQuery } = this.props;
+      onChange({ ...query, pxlScript: option.value });
+      onRunQuery();
     }
   }
 


### PR DESCRIPTION
Remove the map with scripts which was previously used by options. Instead store scripts in the option list object which simplifies script string access by the plugin.

Signed-off-by: Taras Priadka <tpriadka@pixielabs.ai>