### PR TITLE
Dashboard variables

### DIFF
--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -17,11 +17,19 @@
  */
 
 import { DataSourceInstanceSettings } from '@grafana/data';
-import { DataSourceWithBackend } from '@grafana/runtime';
+import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { PixieDataSourceOptions, PixieDataQuery } from './types';
 
 export class DataSource extends DataSourceWithBackend<PixieDataQuery, PixieDataSourceOptions> {
   constructor(instanceSettings: DataSourceInstanceSettings<PixieDataSourceOptions>) {
     super(instanceSettings);
+  }
+
+  applyTemplateVariables(query: PixieDataQuery) {
+    const templateSrv = getTemplateSrv();
+    return {
+      ...query,
+      pxlScript: query.pxlScript ? templateSrv.replace(query.pxlScript) : '',
+    };
   }
 }

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { DataSourceInstanceSettings } from '@grafana/data';
+import { DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
 import { PixieDataSourceOptions, PixieDataQuery } from './types';
 
@@ -25,11 +25,14 @@ export class DataSource extends DataSourceWithBackend<PixieDataQuery, PixieDataS
     super(instanceSettings);
   }
 
-  applyTemplateVariables(query: PixieDataQuery) {
-    const templateSrv = getTemplateSrv();
+  applyTemplateVariables(query: PixieDataQuery, scopedVars: ScopedVars) {
     return {
       ...query,
-      pxlScript: query.pxlScript ? templateSrv.replace(query.pxlScript) : '',
+      pxlScript: query.pxlScript
+        ? getTemplateSrv().replace(query.pxlScript, {
+            ...scopedVars,
+          })
+        : '',
     };
   }
 }


### PR DESCRIPTION
Add support for dashboard variables. Depends on #42 

For example here,
```
df = px.DataFrame(table='http_events', start_time=__time_from)
df['cluster'] = '$clusters'
```
The `$clusters` will get replaced with the dashboard variable value.