### PR TITLE
Add variable query to be able to fetch Pixie variables.

### DIFF
--- a/pkg/pixie_plugin.go
+++ b/pkg/pixie_plugin.go
@@ -68,6 +68,7 @@ func (td *PixieDatasource) QueryData(ctx context.Context, req *backend.QueryData
 	return response, nil
 }
 
+// Creates Pixie API client using API key and cloud Address
 func createClient(ctx context.Context, apiKey string, cloudAddr string) (*pxapi.Client, error) {
 	var client *pxapi.Client
 	var err error
@@ -84,16 +85,27 @@ func createClient(ctx context.Context, apiKey string, cloudAddr string) (*pxapi.
 	return client, nil
 }
 
+//Specifies available query types
+type QueryType string
+
+const (
+	RunScript   QueryType = "run-script"
+	GetClusters QueryType = "get-clusters"
+)
+
 type queryBody struct {
+	//The body of a pxl script
 	PxlScript string
 }
 
 type queryModel struct {
-	// The PxL script passed in by the user.
-	QueryType string    `json:"queryType"`
+	//QueryType specifies which API call to call.
+	QueryType QueryType `json:"queryType"`
+	//QueryBody contains any additional information needed to make the API call
 	QueryBody queryBody `json:"queryBody"`
 }
 
+//Handle an incoming query
 func (td *PixieDatasource) query(ctx context.Context, query backend.DataQuery,
 	config map[string]string) (*backend.DataResponse, error) {
 
@@ -116,9 +128,9 @@ func (td *PixieDatasource) query(ctx context.Context, query backend.DataQuery,
 	}
 
 	switch qm.QueryType {
-	case "run-script":
+	case RunScript:
 		return qp.queryScript(ctx, qm.QueryBody, query, clusterID)
-	case "get-clusters":
+	case GetClusters:
 		return qp.queryClusters(ctx, apiToken)
 	default:
 		return nil, fmt.Errorf("Unknown query type: %v", qm.QueryType)

--- a/pkg/pixie_plugin.go
+++ b/pkg/pixie_plugin.go
@@ -84,10 +84,14 @@ func createClient(ctx context.Context, apiKey string, cloudAddr string) (*pxapi.
 	return client, nil
 }
 
+type queryBody struct {
+	PxlScript string
+}
+
 type queryModel struct {
 	// The PxL script passed in by the user.
-	QueryType string                 `json:"queryType"`
-	QueryBody map[string]interface{} `json:"queryBody"`
+	QueryType string    `json:"queryType"`
+	QueryBody queryBody `json:"queryBody"`
 }
 
 func (td *PixieDatasource) query(ctx context.Context, query backend.DataQuery,
@@ -113,7 +117,7 @@ func (td *PixieDatasource) query(ctx context.Context, query backend.DataQuery,
 
 	switch qm.QueryType {
 	case "run-script":
-		return qp.queryScript(ctx, qm, query, clusterID)
+		return qp.queryScript(ctx, qm.QueryBody, query, clusterID)
 	case "get-clusters":
 		return qp.queryClusters(ctx, apiToken)
 	default:

--- a/pkg/pixie_plugin.go
+++ b/pkg/pixie_plugin.go
@@ -85,7 +85,7 @@ func createClient(ctx context.Context, apiKey string, cloudAddr string) (*pxapi.
 	return client, nil
 }
 
-//Specifies available query types
+// Specifies available query types
 type QueryType string
 
 const (
@@ -94,18 +94,18 @@ const (
 )
 
 type queryBody struct {
-	//The body of a pxl script
+	// The body of a pxl script
 	PxlScript string
 }
 
 type queryModel struct {
-	//QueryType specifies which API call to call.
+	// QueryType specifies which API call to call.
 	QueryType QueryType `json:"queryType"`
-	//QueryBody contains any additional information needed to make the API call
+	// QueryBody contains any additional information needed to make the API call
 	QueryBody queryBody `json:"queryBody"`
 }
 
-//Handle an incoming query
+// Handle an incoming query
 func (td *PixieDatasource) query(ctx context.Context, query backend.DataQuery,
 	config map[string]string) (*backend.DataResponse, error) {
 

--- a/pkg/pixie_plugin.go
+++ b/pkg/pixie_plugin.go
@@ -215,8 +215,11 @@ func (td *PixieDatasource) queryClusters(ctx context.Context, apiToken string) (
 	vizierNames := make([]string, 0)
 
 	for _, vizier := range viziers {
-		vizierIds = append(vizierIds, vizier.ID)
-		vizierNames = append(vizierNames, vizier.Name)
+		// Only show connected clusters
+		if vizier.Status != pxapi.VizierStatusDisconnected {
+			vizierIds = append(vizierIds, vizier.ID)
+			vizierNames = append(vizierNames, vizier.Name)
+		}
 	}
 
 	vizierFrame := data.NewFrame(

--- a/pkg/pixie_plugin.go
+++ b/pkg/pixie_plugin.go
@@ -22,49 +22,20 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
-	"strings"
-	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
-	"github.com/grafana/grafana-plugin-sdk-go/data"
 
 	"px.dev/pxapi"
 )
-
-// GrafanaMacro is a type which defines a macro.
-type GrafanaMacro string
 
 const (
 	// Define keys to retrieve configs passed from UI.
 	apiKeyField    = "apiKey"
 	cloudAddrField = "cloudAddr"
 	clusterIDField = "clusterId"
-	// timeFromMacro is the start of the time range of a query.
-	timeFromMacro GrafanaMacro = "__time_from"
-	// timeToMacro is the end of the time range of a query.
-	timeToMacro GrafanaMacro = "__time_to"
-	// intervalMacro is the suggested duration between time points.
-	intervalMacro GrafanaMacro = "__interval"
 )
-
-// replaceTimeMacroInQueryText takes the query text (PxL script to execute)
-// and replaces the time macros with the relevant time objects.
-func replaceTimeMacroInQueryText(queryText string, grafanaMacro GrafanaMacro,
-	timeReplacement time.Time) string {
-	tStr := fmt.Sprintf("%d", timeReplacement.UnixNano())
-	return strings.ReplaceAll(queryText, string(grafanaMacro), tStr)
-}
-
-// replaceIntervalMacroInQueryText takes the query text and replaces
-// interval macro with interval duration specified in Grafana UI.
-func replaceIntervalMacroInQueryText(queryText string, grafanaMacro GrafanaMacro,
-	intervalDuration time.Duration) string {
-	intervalStr := fmt.Sprintf("%d", intervalDuration.Nanoseconds())
-	return strings.ReplaceAll(queryText, string(grafanaMacro), intervalStr)
-}
 
 // createPixieDatasource creates a new Pixie datasource.
 func createPixieDatasource() datasource.ServeOpts {
@@ -103,7 +74,7 @@ type queryModel struct {
 	ClusterFlag bool   `json:bool`
 }
 
-func createVizierClient(ctx context.Context, apiKey string, clusterID string, cloudAddr string) (*pxapi.VizierClient, error) {
+func createClient(ctx context.Context, apiKey string, cloudAddr string) (*pxapi.Client, error) {
 	var client *pxapi.Client
 	var err error
 	// First, create a client connecting to Pixie Cloud.
@@ -115,17 +86,16 @@ func createVizierClient(ctx context.Context, apiKey string, clusterID string, cl
 	if err != nil {
 		return nil, err
 	}
-	// Next, create a client that connects to the particular Vizier instance matching `clusterID`.
-	vzClient, err := client.NewVizierClient(ctx, clusterID)
 
-	if err != nil {
-		return nil, err
-	}
-	return vzClient, nil
+	return client, nil
 }
 
 func (td *PixieDatasource) query(ctx context.Context, query backend.DataQuery,
 	config map[string]string) (*backend.DataResponse, error) {
+
+	apiToken := config[apiKeyField]
+	clusterID := config[clusterIDField]
+	cloudAddr := config[cloudAddrField]
 
 	var qm queryModel
 	err := json.Unmarshal(query.JSON, &qm)
@@ -133,109 +103,16 @@ func (td *PixieDatasource) query(ctx context.Context, query backend.DataQuery,
 		return nil, fmt.Errorf("Error unmarshalling JSON: %v", err)
 	}
 
-	apiToken := config[apiKeyField]
-	clusterID := config[clusterIDField]
-	cloudAddr := config[cloudAddrField]
+	client, err := createClient(ctx, apiToken, cloudAddr)
+	qp := PixieQueryProcessor{
+		client: client,
+	}
 
 	if qm.ClusterFlag {
-		return td.queryClusters(ctx, apiToken)
+		return qp.queryClusters(ctx, apiToken)
+	} else {
+		return qp.queryScript(ctx, qm, query, clusterID)
 	}
-
-	vz, err := createVizierClient(ctx, apiToken, clusterID, cloudAddr)
-	if err != nil {
-		log.DefaultLogger.Error(fmt.Sprintf("Unable to create Vizier Client: %+v", err))
-		return nil, err
-	}
-
-	response := &backend.DataResponse{}
-
-	// Create TableMuxer to accept results table.
-	tm := &PixieToGrafanaTableMux{}
-
-	// Update macros in query text.
-	qm.PxlScript = replaceTimeMacroInQueryText(qm.PxlScript, timeFromMacro,
-		query.TimeRange.From)
-	qm.PxlScript = replaceTimeMacroInQueryText(qm.PxlScript, timeToMacro,
-		query.TimeRange.To)
-	qm.PxlScript = replaceIntervalMacroInQueryText(qm.PxlScript, intervalMacro,
-		query.Interval)
-
-	// Execute the PxL script.
-	resultSet, err := vz.ExecuteScript(ctx, qm.PxlScript, tm)
-	if err != nil && err != io.EOF {
-		log.DefaultLogger.Warn("Can't execute script.")
-		return nil, err
-	}
-
-	// Receive the PxL script results.
-	defer resultSet.Close()
-	if err := resultSet.Stream(); err != nil {
-		streamStrErr := fmt.Errorf("got error : %+v, while streaming", err)
-		response.Error = streamStrErr
-		log.DefaultLogger.Error(streamStrErr.Error())
-	}
-
-	// Add the frames to the response.
-	for _, tablePrinter := range tm.pxTablePrinterLst {
-		// If time series schema long && time_ column, convert to wide. Otherwise
-		// proceed as normal.
-		tsSchema := tablePrinter.frame.TimeSeriesSchema()
-		if tablePrinter.FormatGrafanaTimeFrame() && tsSchema.Type == data.TimeSeriesTypeLong {
-			wideFrame, err := data.LongToWide(tablePrinter.frame,
-				&data.FillMissing{Mode: data.FillModeNull})
-			if err != nil {
-				return nil, err
-			}
-			response.Frames = append(response.Frames, wideFrame)
-		} else {
-			response.Frames = append(response.Frames,
-				tablePrinter.frame)
-		}
-	}
-	return response, nil
-}
-
-func (td *PixieDatasource) queryClusters(ctx context.Context, apiToken string) (*backend.DataResponse, error) {
-
-	response := &backend.DataResponse{}
-
-	client, err := pxapi.NewClient(ctx, pxapi.WithAPIKey(apiToken))
-	if err != nil {
-		return nil, fmt.Errorf("Error unmarshalling JSON: %v", err)
-	}
-
-	var viziers []*pxapi.VizierInfo
-	viziers, err = client.ListViziers(ctx)
-
-	if err != nil {
-		return nil, fmt.Errorf("Error with getting viziers: $s", err)
-	}
-
-	vizierIds := make([]string, 0)
-	vizierNames := make([]string, 0)
-
-	for _, vizier := range viziers {
-		// Only show connected clusters
-		if vizier.Status != pxapi.VizierStatusDisconnected {
-			vizierIds = append(vizierIds, vizier.ID)
-			vizierNames = append(vizierNames, vizier.Name)
-		}
-	}
-
-	vizierFrame := data.NewFrame(
-		"Vizier Clusters",
-		data.NewField("id", data.Labels{}, vizierIds),
-		data.NewField("name", data.Labels{}, vizierNames),
-	)
-
-	response.Frames = append(response.Frames, vizierFrame)
-
-	backend.Logger.Debug(fmt.Sprintf("number of viziers: $d", len(viziers)))
-	backend.Logger.Debug(fmt.Sprintf("id: $s, name: $s, status: $s", viziers[0].ID, viziers[0].Name, viziers[0].Status))
-
-	backend.Logger.Debug(vizierFrame.StringTable(10, 10))
-
-	return response, nil
 }
 
 // CheckHealth implements the Grafana service health check API.
@@ -244,7 +121,14 @@ func (td *PixieDatasource) CheckHealth(ctx context.Context, req *backend.CheckHe
 	message := "Connection to Pixie cluster successfully configured"
 	config := req.PluginContext.DataSourceInstanceSettings.DecryptedSecureJSONData
 
-	vz, err := createVizierClient(ctx, config[apiKeyField], config[clusterIDField], config[cloudAddrField])
+	client, err := createClient(ctx, config[apiKeyField], config[cloudAddrField])
+	if err != nil {
+		status = backend.HealthStatusError
+		message = fmt.Sprintf("Error connecting Pixie client: %s", err.Error())
+	}
+
+	vz, err := client.NewVizierClient(ctx, config[clusterIDField])
+
 	if vz == nil || err != nil {
 		status = backend.HealthStatusError
 		message = fmt.Sprintf("Error connecting to Vizier: %s", err.Error())

--- a/pkg/pixie_queries.go
+++ b/pkg/pixie_queries.go
@@ -81,17 +81,17 @@ func (qp PixieQueryProcessor) queryScript(
 
 	// Create TableMuxer to accept results table.
 	tm := &PixieToGrafanaTableMux{}
-
+	pxlScript := qm.QueryBody["PxlScript"].(string)
 	// Update macros in query text.
-	qm.PxlScript = replaceTimeMacroInQueryText(qm.PxlScript, timeFromMacro,
+	pxlScript = replaceTimeMacroInQueryText(pxlScript, timeFromMacro,
 		query.TimeRange.From)
-	qm.PxlScript = replaceTimeMacroInQueryText(qm.PxlScript, timeToMacro,
+	pxlScript = replaceTimeMacroInQueryText(pxlScript, timeToMacro,
 		query.TimeRange.To)
-	qm.PxlScript = replaceIntervalMacroInQueryText(qm.PxlScript, intervalMacro,
+	pxlScript = replaceIntervalMacroInQueryText(pxlScript, intervalMacro,
 		query.Interval)
 
 	// Execute the PxL script.
-	resultSet, err := vz.ExecuteScript(ctx, qm.PxlScript, tm)
+	resultSet, err := vz.ExecuteScript(ctx, pxlScript, tm)
 	if err != nil && err != io.EOF {
 		log.DefaultLogger.Warn("Can't execute script.")
 		return nil, err

--- a/pkg/pixie_queries.go
+++ b/pkg/pixie_queries.go
@@ -60,10 +60,12 @@ func replaceIntervalMacroInQueryText(queryText string, grafanaMacro GrafanaMacro
 	return strings.ReplaceAll(queryText, string(grafanaMacro), intervalStr)
 }
 
+// PixieQueryProcessor is a type which handles different PixieAPI calls and returns a Grafana response
 type PixieQueryProcessor struct {
 	client *pxapi.Client
 }
 
+// queryScript sends a request to Pixie with pxlScript and returns DataResponse about the current cluster
 func (qp PixieQueryProcessor) queryScript(
 	ctx context.Context,
 	qm queryBody,
@@ -125,6 +127,7 @@ func (qp PixieQueryProcessor) queryScript(
 	return response, nil
 }
 
+// queryClusters sends a request to Pixie, and returns a DataResponse with healthy clusters
 func (qp PixieQueryProcessor) queryClusters(ctx context.Context, apiToken string) (*backend.DataResponse, error) {
 	response := &backend.DataResponse{}
 	viziers, err := qp.client.ListViziers(ctx)

--- a/pkg/pixie_queries.go
+++ b/pkg/pixie_queries.go
@@ -66,7 +66,7 @@ type PixieQueryProcessor struct {
 
 func (qp PixieQueryProcessor) queryScript(
 	ctx context.Context,
-	qm queryModel,
+	qm queryBody,
 	query backend.DataQuery,
 	clusterID string,
 ) (*backend.DataResponse, error) {
@@ -81,7 +81,7 @@ func (qp PixieQueryProcessor) queryScript(
 
 	// Create TableMuxer to accept results table.
 	tm := &PixieToGrafanaTableMux{}
-	pxlScript := qm.QueryBody["PxlScript"].(string)
+	pxlScript := qm.PxlScript
 	// Update macros in query text.
 	pxlScript = replaceTimeMacroInQueryText(pxlScript, timeFromMacro,
 		query.TimeRange.From)

--- a/pkg/pixie_queries.go
+++ b/pkg/pixie_queries.go
@@ -152,10 +152,5 @@ func (qp PixieQueryProcessor) queryClusters(ctx context.Context, apiToken string
 
 	response.Frames = append(response.Frames, vizierFrame)
 
-	backend.Logger.Debug(fmt.Sprintf("number of viziers: $d", len(viziers)))
-	backend.Logger.Debug(fmt.Sprintf("id: $s, name: $s, status: $s", viziers[0].ID, viziers[0].Name, viziers[0].Status))
-
-	backend.Logger.Debug(vizierFrame.StringTable(10, 10))
-
 	return response, nil
 }

--- a/pkg/pixie_queries.go
+++ b/pkg/pixie_queries.go
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+
+	"px.dev/pxapi"
+)
+
+// GrafanaMacro is a type which defines a macro.
+type GrafanaMacro string
+
+const (
+	// timeFromMacro is the start of the time range of a query.
+	timeFromMacro GrafanaMacro = "__time_from"
+	// timeToMacro is the end of the time range of a query.
+	timeToMacro GrafanaMacro = "__time_to"
+	// intervalMacro is the suggested duration between time points.
+	intervalMacro GrafanaMacro = "__interval"
+)
+
+// replaceTimeMacroInQueryText takes the query text (PxL script to execute)
+// and replaces the time macros with the relevant time objects.
+func replaceTimeMacroInQueryText(queryText string, grafanaMacro GrafanaMacro,
+	timeReplacement time.Time) string {
+	tStr := fmt.Sprintf("%d", timeReplacement.UnixNano())
+	return strings.ReplaceAll(queryText, string(grafanaMacro), tStr)
+}
+
+// replaceIntervalMacroInQueryText takes the query text and replaces
+// interval macro with interval duration specified in Grafana UI.
+func replaceIntervalMacroInQueryText(queryText string, grafanaMacro GrafanaMacro,
+	intervalDuration time.Duration) string {
+	intervalStr := fmt.Sprintf("%d", intervalDuration.Nanoseconds())
+	return strings.ReplaceAll(queryText, string(grafanaMacro), intervalStr)
+}
+
+type PixieQueryProcessor struct {
+	client *pxapi.Client
+}
+
+func (qp PixieQueryProcessor) queryScript(
+	ctx context.Context,
+	qm queryModel,
+	query backend.DataQuery,
+	clusterID string,
+) (*backend.DataResponse, error) {
+
+	vz, err := qp.client.NewVizierClient(ctx, clusterID)
+	if err != nil {
+		log.DefaultLogger.Error(fmt.Sprintf("Unable to create Vizier Client: %+v", err))
+		return nil, err
+	}
+
+	response := &backend.DataResponse{}
+
+	// Create TableMuxer to accept results table.
+	tm := &PixieToGrafanaTableMux{}
+
+	// Update macros in query text.
+	qm.PxlScript = replaceTimeMacroInQueryText(qm.PxlScript, timeFromMacro,
+		query.TimeRange.From)
+	qm.PxlScript = replaceTimeMacroInQueryText(qm.PxlScript, timeToMacro,
+		query.TimeRange.To)
+	qm.PxlScript = replaceIntervalMacroInQueryText(qm.PxlScript, intervalMacro,
+		query.Interval)
+
+	// Execute the PxL script.
+	resultSet, err := vz.ExecuteScript(ctx, qm.PxlScript, tm)
+	if err != nil && err != io.EOF {
+		log.DefaultLogger.Warn("Can't execute script.")
+		return nil, err
+	}
+
+	// Receive the PxL script results.
+	defer resultSet.Close()
+	if err := resultSet.Stream(); err != nil {
+		streamStrErr := fmt.Errorf("got error : %+v, while streaming", err)
+		response.Error = streamStrErr
+		log.DefaultLogger.Error(streamStrErr.Error())
+	}
+
+	// Add the frames to the response.
+	for _, tablePrinter := range tm.pxTablePrinterLst {
+		// If time series schema long && time_ column, convert to wide. Otherwise
+		// proceed as normal.
+		tsSchema := tablePrinter.frame.TimeSeriesSchema()
+		if tablePrinter.FormatGrafanaTimeFrame() && tsSchema.Type == data.TimeSeriesTypeLong {
+			wideFrame, err := data.LongToWide(tablePrinter.frame,
+				&data.FillMissing{Mode: data.FillModeNull})
+			if err != nil {
+				return nil, err
+			}
+			response.Frames = append(response.Frames, wideFrame)
+		} else {
+			response.Frames = append(response.Frames,
+				tablePrinter.frame)
+		}
+	}
+	return response, nil
+}
+
+func (qp PixieQueryProcessor) queryClusters(ctx context.Context, apiToken string) (*backend.DataResponse, error) {
+	response := &backend.DataResponse{}
+	viziers, err := qp.client.ListViziers(ctx)
+
+	if err != nil {
+		return nil, fmt.Errorf("Error with getting viziers: %s", err)
+	}
+
+	vizierIds := make([]string, 0)
+	vizierNames := make([]string, 0)
+
+	for _, vizier := range viziers {
+		// Only show connected clusters
+		if vizier.Status != pxapi.VizierStatusDisconnected {
+			vizierIds = append(vizierIds, vizier.ID)
+			vizierNames = append(vizierNames, vizier.Name)
+		}
+	}
+
+	vizierFrame := data.NewFrame(
+		"Vizier Clusters",
+		data.NewField("id", data.Labels{}, vizierIds),
+		data.NewField("name", data.Labels{}, vizierNames),
+	)
+
+	response.Frames = append(response.Frames, vizierFrame)
+
+	backend.Logger.Debug(fmt.Sprintf("number of viziers: $d", len(viziers)))
+	backend.Logger.Debug(fmt.Sprintf("id: $s, name: $s, status: $s", viziers[0].ID, viziers[0].Name, viziers[0].Status))
+
+	backend.Logger.Debug(vizierFrame.StringTable(10, 10))
+
+	return response, nil
+}

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -34,13 +34,16 @@ export class DataSource extends DataSourceWithBackend<PixieDataQuery, PixieDataS
   }
 
   applyTemplateVariables(query: PixieDataQuery, scopedVars: ScopedVars) {
+    const pxlScript = query?.queryBody?.pxlScript;
     return {
       ...query,
-      pxlScript: query.pxlScript
-        ? getTemplateSrv().replace(query.pxlScript, {
-            ...scopedVars,
-          })
-        : '',
+      queryBody: {
+        pxlScript: pxlScript
+          ? getTemplateSrv().replace(pxlScript, {
+              ...scopedVars,
+            })
+          : '',
+      },
     };
   }
 
@@ -57,7 +60,7 @@ export class DataSource extends DataSourceWithBackend<PixieDataQuery, PixieDataS
         type: this.type,
         uid: this.uid,
       },
-      clusterFlag: true,
+      queryType: 'get-clusters',
     };
 
     options = {

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -18,7 +18,7 @@
 
 import { DataSourceInstanceSettings, ScopedVars } from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv } from '@grafana/runtime';
-import { PixieDataSourceOptions, PixieDataQuery } from './types';
+import { PixieDataSourceOptions, PixieDataQuery, PixieVariableQuery } from './types';
 
 export class DataSource extends DataSourceWithBackend<PixieDataQuery, PixieDataSourceOptions> {
   constructor(instanceSettings: DataSourceInstanceSettings<PixieDataSourceOptions>) {
@@ -34,5 +34,22 @@ export class DataSource extends DataSourceWithBackend<PixieDataQuery, PixieDataS
           })
         : '',
     };
+  }
+
+  async fetchMetricNames(cluster: string) {
+    return {
+      data: [{ name: 'test' }],
+    };
+  }
+
+  async metricFindQuery(query: PixieVariableQuery, options?: any) {
+    // Retrieve DataQueryResponse based on query.
+    const response = await this.fetchMetricNames(query.cluster);
+
+    // Convert query results to a MetricFindValue[]
+    const values = response.data.map((frame) => ({ text: frame.name }));
+    console.log(values);
+
+    return values;
   }
 }

--- a/src/module.ts
+++ b/src/module.ts
@@ -21,7 +21,9 @@ import { DataSource } from './datasource';
 import { ConfigEditor } from './config_editor';
 import { QueryEditor } from './query_editor';
 import { PixieDataQuery, PixieDataSourceOptions } from './types';
+import { VariableQueryEditor } from 'variable_query_editor';
 
 export const plugin = new DataSourcePlugin<DataSource, PixieDataQuery, PixieDataSourceOptions>(DataSource)
   .setConfigEditor(ConfigEditor)
-  .setQueryEditor(QueryEditor);
+  .setQueryEditor(QueryEditor)
+  .setVariableQueryEditor(VariableQueryEditor);

--- a/src/query_editor.tsx
+++ b/src/query_editor.tsx
@@ -60,7 +60,7 @@ export class QueryEditor extends PureComponent<Props> {
 
   render() {
     const query = defaults(this.props.query, defaultQuery);
-    const { pxlScript } = query;
+    const pxlScript = query?.pxlScript;
 
     return (
       <div className="gf-form" style={{ margin: '10px', display: 'block' }}>
@@ -71,7 +71,7 @@ export class QueryEditor extends PureComponent<Props> {
           defaultValue={scriptOptions[0]}
         />
         <Editor
-          value={pxlScript}
+          value={pxlScript === undefined ? '' : pxlScript}
           onValueChange={this.onPxlScriptChange.bind(this)}
           highlight={(code) => {
             if (code !== undefined) {

--- a/src/query_editor.tsx
+++ b/src/query_editor.tsx
@@ -46,14 +46,22 @@ const editorStyle = {
 export class QueryEditor extends PureComponent<Props> {
   onPxlScriptChange(event: string) {
     const { onChange, query, onRunQuery } = this.props;
-    onChange({ ...query, queryType: 'run-script', queryBody: { pxlScript: event } });
+    onChange({
+      ...query,
+      queryType: 'run-script' as const,
+      queryBody: { pxlScript: event },
+    });
     onRunQuery();
   }
 
   onScriptSelect(option: SelectableValue<string>) {
     if (option.value !== undefined) {
       const { onChange, query, onRunQuery } = this.props;
-      onChange({ ...query, queryType: 'run-script', queryBody: { pxlScript: option.value } });
+      onChange({
+        ...query,
+        queryType: 'run-script' as const,
+        queryBody: { pxlScript: option.value },
+      });
       onRunQuery();
     }
   }
@@ -71,7 +79,7 @@ export class QueryEditor extends PureComponent<Props> {
           defaultValue={scriptOptions[0]}
         />
         <Editor
-          value={pxlScript === undefined ? '' : pxlScript}
+          value={pxlScript ?? ''}
           onValueChange={this.onPxlScriptChange.bind(this)}
           highlight={(code) => {
             if (code !== undefined) {

--- a/src/query_editor.tsx
+++ b/src/query_editor.tsx
@@ -46,21 +46,21 @@ const editorStyle = {
 export class QueryEditor extends PureComponent<Props> {
   onPxlScriptChange(event: string) {
     const { onChange, query, onRunQuery } = this.props;
-    onChange({ ...query, pxlScript: event });
+    onChange({ ...query, queryType: 'run-script', queryBody: { pxlScript: event } });
     onRunQuery();
   }
 
   onScriptSelect(option: SelectableValue<string>) {
     if (option.value !== undefined) {
       const { onChange, query, onRunQuery } = this.props;
-      onChange({ ...query, pxlScript: option.value });
+      onChange({ ...query, queryType: 'run-script', queryBody: { pxlScript: option.value } });
       onRunQuery();
     }
   }
 
   render() {
     const query = defaults(this.props.query, defaultQuery);
-    const pxlScript = query?.pxlScript;
+    const pxlScript = query?.queryBody?.pxlScript;
 
     return (
       <div className="gf-form" style={{ margin: '10px', display: 'block' }}>

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,12 +22,17 @@ import { scriptOptions } from 'pxl_scripts';
 // PixieDataQuery is the interface representing a query in Pixie.
 // Pixie queries use PxL, Pixie's query language.
 export interface PixieDataQuery extends DataQuery {
-  pxlScript?: string;
-  clusterFlag?: boolean;
+  queryType: string;
+  queryBody?: {
+    pxlScript?: string;
+  };
 }
 
 export const defaultQuery: Partial<PixieDataQuery> = {
-  pxlScript: scriptOptions[0].value,
+  queryType: 'run-script',
+  queryBody: {
+    pxlScript: scriptOptions[0].value,
+  },
 };
 
 export interface PixieDataSourceOptions extends DataSourceJsonData {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,11 +22,8 @@ import { scriptOptions } from 'pxl_scripts';
 // PixieDataQuery is the interface representing a query in Pixie.
 // Pixie queries use PxL, Pixie's query language.
 export interface PixieDataQuery extends DataQuery {
-  pxlScript: string;
-}
-
-export interface PixieVariableQuery {
-  cluster: string;
+  pxlScript?: string;
+  clusterFlag?: boolean;
 }
 
 export const defaultQuery: Partial<PixieDataQuery> = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,17 +19,25 @@
 import { DataQuery, DataSourceJsonData } from '@grafana/data';
 import { scriptOptions } from 'pxl_scripts';
 
+// Types of available queries to the backend
+export type QueryType = 'run-script' | 'get-clusters';
+
+// Describes variable query to be sent to the backend.
+export interface PixieVariableQuery {
+  queryType: QueryType;
+}
+
 // PixieDataQuery is the interface representing a query in Pixie.
 // Pixie queries use PxL, Pixie's query language.
 export interface PixieDataQuery extends DataQuery {
-  queryType: string;
+  queryType: QueryType;
   queryBody?: {
     pxlScript?: string;
   };
 }
 
 export const defaultQuery: Partial<PixieDataQuery> = {
-  queryType: 'run-script',
+  queryType: 'run-script' as const,
   queryBody: {
     pxlScript: scriptOptions[0].value,
   },

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,10 @@ export interface PixieDataQuery extends DataQuery {
   pxlScript: string;
 }
 
+export interface PixieVariableQuery {
+  cluster: string;
+}
+
 export const defaultQuery: Partial<PixieDataQuery> = {
   pxlScript: scriptOptions[0].value,
 };

--- a/src/variable_query_editor.tsx
+++ b/src/variable_query_editor.tsx
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SelectableValue } from '@grafana/data';
+import { Select } from '@grafana/ui';
+import React, { useState } from 'react';
+import { PixieVariableQuery } from './types';
+
+interface VariableQueryProps {
+  query: PixieVariableQuery;
+  onChange: (query: PixieVariableQuery, definition: string) => void;
+}
+
+export const VariableQueryEditor: React.FC<VariableQueryProps> = ({ onChange, query }) => {
+  const [state, setState] = useState(query);
+
+  const onClusterSelect = (option: SelectableValue<string>) => {
+    if (option.label !== undefined) {
+      console.log(option);
+      setState({
+        ...state,
+        cluster: option.label,
+      });
+    }
+  };
+
+  const valueOptions = [{ label: 'Clusters' }];
+
+  return (
+    <>
+      <div className="gf-form">
+        <span className="gf-form-label width-10">Fetchable Data</span>
+        <Select options={valueOptions} width={32} onChange={onClusterSelect} defaultValue={valueOptions[0]} />
+      </div>
+    </>
+  );
+};

--- a/src/variable_query_editor.tsx
+++ b/src/variable_query_editor.tsx
@@ -18,28 +18,25 @@
 
 import { SelectableValue } from '@grafana/data';
 import { Select } from '@grafana/ui';
-import React, { useState } from 'react';
-import { PixieVariableQuery } from './types';
+import React from 'react'; //, { useState } from 'react';
 
 interface VariableQueryProps {
-  query: PixieVariableQuery;
-  onChange: (query: PixieVariableQuery, definition: string) => void;
+  query: string;
+  onChange: (query: string, definition: string) => void;
 }
 
 export const VariableQueryEditor: React.FC<VariableQueryProps> = ({ onChange, query }) => {
-  const [state, setState] = useState(query);
+  // const [state, setState] = useState(query);
 
   const onClusterSelect = (option: SelectableValue<string>) => {
-    if (option.label !== undefined) {
+    if (option.value !== undefined && option.label !== undefined) {
       console.log(option);
-      setState({
-        ...state,
-        cluster: option.label,
-      });
+      // setState(option.value);
+      onChange(option.value, option.label);
     }
   };
 
-  const valueOptions = [{ label: 'Clusters' }];
+  const valueOptions = [{ label: 'Clusters', value: 'get-clusters' }];
 
   return (
     <>

--- a/src/variable_query_editor.tsx
+++ b/src/variable_query_editor.tsx
@@ -18,7 +18,7 @@
 
 import { SelectableValue } from '@grafana/data';
 import { Select } from '@grafana/ui';
-import React from 'react'; //, { useState } from 'react';
+import React from 'react';
 
 interface VariableQueryProps {
   query: string;
@@ -26,12 +26,8 @@ interface VariableQueryProps {
 }
 
 export const VariableQueryEditor: React.FC<VariableQueryProps> = ({ onChange, query }) => {
-  // const [state, setState] = useState(query);
-
   const onClusterSelect = (option: SelectableValue<string>) => {
     if (option.value !== undefined && option.label !== undefined) {
-      console.log(option);
-      // setState(option.value);
       onChange(option.value, option.label);
     }
   };

--- a/src/variable_query_editor.tsx
+++ b/src/variable_query_editor.tsx
@@ -19,20 +19,21 @@
 import { SelectableValue } from '@grafana/data';
 import { Select } from '@grafana/ui';
 import React from 'react';
+import { PixieVariableQuery, QueryType } from 'types';
 
+//Specifies what properties the VariableQueryEditor receives in constructor
 interface VariableQueryProps {
-  query: string;
-  onChange: (query: string, definition: string) => void;
+  onChange: (query: PixieVariableQuery, definition: string) => void;
 }
 
-export const VariableQueryEditor: React.FC<VariableQueryProps> = ({ onChange, query }) => {
-  const onClusterSelect = (option: SelectableValue<string>) => {
+export const VariableQueryEditor: React.FC<VariableQueryProps> = ({ onChange }) => {
+  const onClusterSelect = (option: SelectableValue<QueryType>) => {
     if (option.value !== undefined && option.label !== undefined) {
-      onChange(option.value, option.label);
+      onChange({ queryType: option.value }, option.label);
     }
   };
 
-  const valueOptions = [{ label: 'Clusters', value: 'get-clusters' }];
+  const valueOptions: Array<SelectableValue<QueryType>> = [{ label: 'Clusters', value: 'get-clusters' as const }];
 
   return (
     <>


### PR DESCRIPTION
Adding ability to query Pixie Grafana go backend to fetch and display Pixie clusters. This PR doesn't add the functionality to switch clusters for the whole dashboard, as in dashboard variables are not going to function yet. Dashboard cluster change will be introduced in the next PR.

Structural changes:
- Restructured Go query schema. Now looks like:
```
{
  queryType: str
  queryBody? {
    pxlScript?: str
  }
}
```
- New query structure allows switching on different types of requests that we may add in the future
 
Go backend:
- Refactored code into query type processor and query processor. Query type processor switches on different types of queries. Query processor actually sends a proper request using Pixie API based on the query type.
- Query processing module now supports queries to run the pxl script, or queries vizier clusters.
- Added function to query vizier clusters to support Cluster dashboard variable.

Front-end:
- Add functionality to `Datasource` which sends a query to plugin backend.
- Add `VariableQueryEditor` which adds a dropdown menu to `Variables` page in the dashboard settings and allows to create a dashboard variable. For now there's only a single item to get clusters.
- Update `PixieDataQuery` interface to reflect the schema changes.


Signed-off-by: Taras Priadka <tpriadka@pixielabs.ai>