### PR TITLE
Add line numbers to the editor

### DIFF
--- a/src/query_editor.css
+++ b/src/query_editor.css
@@ -1,0 +1,21 @@
+.code-editor {
+    counter-reset: line;
+  }
+
+.code-editor #code-area {
+    outline: none;
+    padding-left: 60px !important;
+}
+
+.code-editor pre {
+    padding-left: 60px !important;
+}
+
+.code-editor .editor-line-number {
+    position: absolute;
+    left: 0px;
+    color: #cccccc;
+    text-align: right;
+    width: 40px;
+    font-weight: 100;
+}

--- a/src/query_editor.tsx
+++ b/src/query_editor.tsx
@@ -26,6 +26,7 @@ import Editor from 'react-simple-code-editor';
 import { highlight, languages } from 'prismjs';
 import 'prismjs/components/prism-python';
 import 'prism-themes/themes/prism-vsc-dark-plus.css';
+import './query_editor.css';
 
 import { DataSource } from './datasource';
 import { scriptOptions } from 'pxl_scripts';
@@ -81,15 +82,20 @@ export class QueryEditor extends PureComponent<Props> {
         <Editor
           value={pxlScript ?? ''}
           onValueChange={this.onPxlScriptChange.bind(this)}
+          textareaId="code-area"
           highlight={(code) => {
             if (code !== undefined) {
-              return highlight(code, languages.python, 'python');
+              return highlight(code, languages.python, 'python')
+                .split('\n')
+                .map((line, i) => `<span class='editor-line-number'>${i + 1}</span>${line}`)
+                .join('\n');
             } else {
               return '';
             }
           }}
           padding={10}
           style={editorStyle}
+          className="code-editor"
         />
       </div>
     );


### PR DESCRIPTION
Adding line numbers to our editor to make it easier for users to navigate and fix errors in their scripts.

One comment about using css here. Webpack of the component injects a bunch of default `style` information into the component upon build, so the style information is not propagated into the component from css. Therefore we still need to use `style={editorStyle}` to get the right styles for the component.

Editor with line numbers:
<img width="1011" alt="image" src="https://user-images.githubusercontent.com/14134797/173441676-1273deaf-2162-40c0-94b5-59197ba9030c.png">


Signed-off-by: Taras Priadka <tpriadka@pixielabs.ai>