### PR TITLE
Add back default clusterID to the config and improve health checking.

### DIFF
--- a/pkg/pixie_plugin.go
+++ b/pkg/pixie_plugin.go
@@ -32,11 +32,9 @@ import (
 
 const (
 	// Define keys to retrieve configs passed from UI.
-	apiKeyField       = "apiKey"
-	API_KEY_LENGTH    = 43
-	clusterIDField    = "clusterId"
-	CLUSTER_ID_LENGTH = 36
-	cloudAddrField    = "cloudAddr"
+	apiKeyField    = "apiKey"
+	clusterIDField = "clusterId"
+	cloudAddrField = "cloudAddr"
 )
 
 // createPixieDatasource creates a new Pixie datasource.
@@ -175,10 +173,6 @@ func (td *PixieDatasource) query(ctx context.Context, query backend.DataQuery,
 		return nil, fmt.Errorf("no clusterID present in the request or default clusterID configured. Please set `pixieCluster` dashboard variable to `Pixie Datasource`->`Clusters`")
 	}
 
-	if len(qm.QueryBody.ClusterID) != 0 {
-		clusterID = qm.QueryBody.ClusterID
-	}
-
 	switch qm.QueryType {
 	case RunScript:
 		return qp.queryScript(ctx, qm.QueryBody.PxlScript, query, clusterID)
@@ -203,20 +197,6 @@ func (td *PixieDatasource) CheckHealth(ctx context.Context, req *backend.CheckHe
 	message := "Connection to Pixie cluster successfully configured"
 	config := req.PluginContext.DataSourceInstanceSettings.DecryptedSecureJSONData
 
-	if status == backend.HealthStatusOk {
-		if len(config[apiKeyField]) != API_KEY_LENGTH {
-			message = fmt.Sprintf("Error with API key, incorrect length of the key: %v.", len(config[apiKeyField]))
-			status = backend.HealthStatusError
-		}
-	}
-
-	if status == backend.HealthStatusOk {
-		if len(config[clusterIDField]) != CLUSTER_ID_LENGTH && len(config[clusterIDField]) != 0 {
-			message = fmt.Sprintf("Error with cluster id, incorrect length of the id: %v.", len(config[clusterIDField]))
-			status = backend.HealthStatusError
-		}
-	}
-
 	var client *pxapi.Client
 	var err error
 
@@ -230,7 +210,7 @@ func (td *PixieDatasource) CheckHealth(ctx context.Context, req *backend.CheckHe
 
 	if status == backend.HealthStatusOk {
 		// only check the health of clusterID if the user specified clusterID
-		if len(config[clusterIDField]) == CLUSTER_ID_LENGTH {
+		if len(config[clusterIDField]) != 0 {
 			_, err = client.NewVizierClient(ctx, config[clusterIDField])
 			if err != nil {
 				message = fmt.Sprintf("Unable to create Vizier Client: %+v, clusterID: '%+v'", err, config[clusterIDField])

--- a/pkg/pixie_queries.go
+++ b/pkg/pixie_queries.go
@@ -75,7 +75,7 @@ func (qp PixieQueryProcessor) queryScript(
 
 	vz, err := qp.client.NewVizierClient(ctx, clusterID)
 	if err != nil {
-		log.DefaultLogger.Error(fmt.Sprintf("Unable to create Vizier Client: %+v", err))
+		log.DefaultLogger.Error(fmt.Sprintf("Unable to create Vizier Client: %+v, clusterID: '%+v'", err, clusterID))
 		return nil, err
 	}
 

--- a/src/config_editor.tsx
+++ b/src/config_editor.tsx
@@ -40,6 +40,18 @@ export class ConfigEditor extends PureComponent<Props, State> {
     });
   };
 
+  onClusterIdChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { onOptionsChange, options } = this.props;
+
+    onOptionsChange({
+      ...options,
+      secureJsonData: {
+        ...options?.secureJsonData,
+        clusterId: event.target.value,
+      },
+    });
+  };
+
   onCloudAddrChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { onOptionsChange, options } = this.props;
 
@@ -64,6 +76,22 @@ export class ConfigEditor extends PureComponent<Props, State> {
       secureJsonData: {
         ...options.secureJsonData,
         apiKey: '',
+      },
+    });
+  };
+
+  onResetClusterId = () => {
+    const { onOptionsChange, options } = this.props;
+
+    onOptionsChange({
+      ...options,
+      secureJsonFields: {
+        ...options.secureJsonFields,
+        clusterId: false,
+      },
+      secureJsonData: {
+        ...options.secureJsonData,
+        clusterId: '',
       },
     });
   };
@@ -102,6 +130,21 @@ export class ConfigEditor extends PureComponent<Props, State> {
               inputWidth={20}
               onReset={this.onResetAPIKey}
               onChange={this.onAPIKeyChange}
+            />
+          </div>
+        </div>
+
+        <div className="gf-form-inline">
+          <div className="gf-form">
+            <SecretFormField
+              isConfigured={(secureJsonFields && secureJsonFields.clusterId) as boolean}
+              value={secureJsonData.clusterId || ''}
+              label="Cluster ID"
+              placeholder="Default Cluster ID"
+              labelWidth={20}
+              inputWidth={20}
+              onReset={this.onResetClusterId}
+              onChange={this.onClusterIdChange}
             />
           </div>
         </div>

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -176,7 +176,6 @@ export class DataSource extends DataSourceWithBackend<PixieDataQuery, PixieDataS
   }
 
   async metricFindQuery(query: PixieVariableQuery, options?: any): Promise<MetricFindValue[]> {
-    // const variableName: string = options.variable.name;
     // Make sure the query is not empty. Variable query editor will send empty string if user haven't clicked on dropdown menu
     query = query || { queryType: 'get-clusters' as const };
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -16,14 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import {
-  DataFrame,
-  DataSourceInstanceSettings,
-  MetricFindValue,
-  ScopedVars,
-  toDataFrame,
-  VariableModel,
-} from '@grafana/data';
+import { DataFrame, DataSourceInstanceSettings, MetricFindValue, ScopedVars, toDataFrame } from '@grafana/data';
 import { DataSourceWithBackend, getTemplateSrv, FetchResponse, getBackendSrv, BackendSrv } from '@grafana/runtime';
 import {
   PixieDataSourceOptions,
@@ -31,10 +24,10 @@ import {
   PixieVariableQuery,
   CLUSTER_VARIABLE_NAME as CLUSTER_VARIABLE_NAME,
   QueryType,
-  checkExhaustive,
 } from './types';
 import { getColumnsScript } from './column_filtering';
 import { getGroupByScript } from './groupby';
+import { checkExhaustive, getClusterId } from 'utils';
 
 const timeVars = [
   ['$__from', '__time_from'],
@@ -55,16 +48,6 @@ export class DataSource extends DataSourceWithBackend<PixieDataQuery, PixieDataS
   constructor(instanceSettings: DataSourceInstanceSettings<PixieDataSourceOptions>) {
     super(instanceSettings);
     this.backendSrv = getBackendSrv();
-  }
-
-  getClusterId(): string {
-    const dashboardVariables: VariableModel[] = getTemplateSrv().getVariables();
-
-    // find cluster variable and convert it to any since the variable value field is not exposed
-    const pixieClusterIdVariable = dashboardVariables.find(
-      (variable) => variable.name === CLUSTER_VARIABLE_NAME
-    ) as any;
-    return pixieClusterIdVariable?.current?.value ?? '';
   }
 
   applyTemplateVariables(query: PixieDataQuery, scopedVars: ScopedVars) {
@@ -101,7 +84,7 @@ export class DataSource extends DataSourceWithBackend<PixieDataQuery, PixieDataS
       ...query,
       queryBody: {
         ...query.queryBody,
-        clusterID: this.getClusterId(),
+        clusterID: getClusterId() ?? '',
         pxlScript: pxlScript
           ? getTemplateSrv().replace(pxlScript, {
               ...scopedVars,

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,8 @@ export interface PixieSecureDataSourceOptions {
   apiKey?: string;
   // Address of Pixie cloud.
   cloudAddr?: string;
+  // ID of the Pixie cluster to query.
+  clusterId?: string;
 }
 
 export function checkExhaustive(val: never): never {

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,7 +78,3 @@ export interface PixieSecureDataSourceOptions {
   // ID of the Pixie cluster to query.
   clusterId?: string;
 }
-
-export function checkExhaustive(val: never): never {
-  throw new Error(`Unexpected value: ${JSON.stringify(val)}`);
-}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018- The Pixie Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { VariableModel } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
+import { CLUSTER_VARIABLE_NAME } from 'types';
+
+/**
+ * Return the value of the dashboard variable if present.
+ */
+export function getClusterId(): string | undefined {
+  const dashboardVariables: VariableModel[] = getTemplateSrv().getVariables();
+
+  // find cluster variable and convert it to any since the variable value field is not exposed
+  const pixieClusterIdVariable = dashboardVariables.find((variable) => variable.name === CLUSTER_VARIABLE_NAME) as any;
+  return pixieClusterIdVariable?.current?.value;
+}
+
+export function checkExhaustive(val: never): never {
+  throw new Error(`Unexpected value: ${JSON.stringify(val)}`);
+}

--- a/src/variable_query_editor.tsx
+++ b/src/variable_query_editor.tsx
@@ -22,6 +22,7 @@ import React, { useState } from 'react';
 
 import { CLUSTER_VARIABLE_NAME, PixieVariableQuery, QueryType } from './types';
 import './styles.css';
+import { getClusterId } from 'utils';
 
 //Specifies what properties the VariableQueryEditor receives in constructor
 interface VariableQueryProps {
@@ -38,7 +39,8 @@ export const VariableQueryEditor: React.FC<VariableQueryProps> = ({ onChange }) 
   ];
 
   let [currentValue, setCurrentValue] = useState(valueOptions[0]);
-  let [clusterID, setClusterID] = useState(`\$${CLUSTER_VARIABLE_NAME}`);
+  let clusterIDVariableSet = getClusterId() ? true : false;
+  let [clusterID, setClusterID] = useState(clusterIDVariableSet ? `\$${CLUSTER_VARIABLE_NAME}` : '');
 
   const onSubmit = () => {
     let query: PixieVariableQuery = { queryType: currentValue.value! };


### PR DESCRIPTION
Adding back the default clusterId to the datasource config to allow clusterId setting during Grafana provisioning.

Also improving health checks to better document errors to the users of the plugin.

Addresses an issue in https://github.com/pixie-io/grafana-plugin/issues/54

Signed-off-by: Taras Priadka <tpriadka@pixielabs.ai>