### PR TITLE
Update/Retain Options Chosen in Selects

### DIFF
--- a/src/groupby.tsx
+++ b/src/groupby.tsx
@@ -143,6 +143,7 @@ export class GroupbyComponents extends PureComponent<Props> {
             onChange={this.onGroupBySelect.bind(this)}
             closeMenuOnSelect={false}
             width={34}
+            value={query.queryMeta?.selectedColGroupby ?? undefined}
           />
         </div>
         <div style={{ marginTop: '10px', marginLeft: '10px' }}>

--- a/src/query_editor.tsx
+++ b/src/query_editor.tsx
@@ -59,6 +59,7 @@ export class QueryEditor extends PureComponent<Props> {
       onChange({
         ...query,
         queryType: QueryType.RunScript,
+        queryScript: option ?? null,
         queryBody: { pxlScript: option?.value.script ?? '' },
         queryMeta: {
           isColDisplay: option.value.isColDisplay || false,
@@ -99,7 +100,8 @@ export class QueryEditor extends PureComponent<Props> {
               options={scriptOptions}
               width={32}
               onChange={this.onScriptSelect.bind(this)}
-              defaultValue={scriptOptions[0]}
+              //defaultValue={scriptOptions[0]}
+              defaultValue={query.queryScript ?? scriptOptions[0]}
             />
           </div>
 

--- a/src/query_editor.tsx
+++ b/src/query_editor.tsx
@@ -66,8 +66,8 @@ export class QueryEditor extends PureComponent<Props> {
           isGroupBy: option.value.isGroupBy || false,
           columnOptions: option.columnOptions,
           groupByColOptions: option.groupByColOptions,
-          selectedColDisplay: [] || null,
-          selectedColGroupby: [] || null,
+          selectedColDisplay: [],
+          selectedColGroupby: [],
           aggData: [],
         },
       });

--- a/src/query_editor.tsx
+++ b/src/query_editor.tsx
@@ -59,7 +59,7 @@ export class QueryEditor extends PureComponent<Props> {
       onChange({
         ...query,
         queryType: QueryType.RunScript,
-        queryScript: option ?? null,
+        queryScript: option,
         queryBody: { pxlScript: option?.value.script ?? '' },
         queryMeta: {
           isColDisplay: option.value.isColDisplay || false,
@@ -117,7 +117,7 @@ export class QueryEditor extends PureComponent<Props> {
                   closeMenuOnSelect={false}
                   width={32}
                   inputId="column-selection"
-                  value={query.queryMeta.selectedColDisplay ?? undefined}
+                  value={query.queryMeta.selectedColDisplay}
                 />
               </>
             )}

--- a/src/query_editor.tsx
+++ b/src/query_editor.tsx
@@ -66,8 +66,8 @@ export class QueryEditor extends PureComponent<Props> {
           isGroupBy: option.value.isGroupBy || false,
           columnOptions: option.columnOptions,
           groupByColOptions: option.groupByColOptions,
-          selectedColDisplay: [],
-          selectedColGroupby: [],
+          selectedColDisplay: [] || null,
+          selectedColGroupby: [] || null,
           aggData: [],
         },
       });
@@ -100,7 +100,6 @@ export class QueryEditor extends PureComponent<Props> {
               options={scriptOptions}
               width={32}
               onChange={this.onScriptSelect.bind(this)}
-              //defaultValue={scriptOptions[0]}
               defaultValue={query.queryScript ?? scriptOptions[0]}
             />
           </div>
@@ -118,6 +117,7 @@ export class QueryEditor extends PureComponent<Props> {
                   closeMenuOnSelect={false}
                   width={32}
                   inputId="column-selection"
+                  value={query.queryMeta.selectedColDisplay ?? undefined}
                 />
               </>
             )}

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,7 +17,7 @@
  */
 
 import { DataQuery, DataSourceJsonData, SelectableValue } from '@grafana/data';
-import { scriptOptions } from './pxl_scripts';
+import { scriptOptions, Script } from './pxl_scripts';
 
 // Types of available queries to the backend
 export const enum QueryType {
@@ -45,6 +45,7 @@ export interface PixieVariableQuery {
 export interface PixieDataQuery extends DataQuery {
   queryType: QueryType;
   clusterID?: string;
+  queryScript?: SelectableValue<Script>;
   queryBody?: {
     clusterID?: string;
     pxlScript?: string;


### PR DESCRIPTION
Fixes the issues of options selected for display/groupby showing up from an older script after a script change and options selected clearing out when the visualization type changes. 