### PR TITLE
Add workaround for 7.5 Grafana linked dashboard variables

### DIFF
--- a/dashboards/px_cluster.json
+++ b/dashboards/px_cluster.json
@@ -721,7 +721,7 @@
         "query": {
           "queryType": "get-clusters"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,

--- a/dashboards/px_http_data.json
+++ b/dashboards/px_http_data.json
@@ -231,7 +231,7 @@
       "type": "table"
     }
   ],
-  "refresh": "",
+  "refresh": 2,
   "schemaVersion": 27,
   "style": "dark",
   "tags": [],
@@ -249,7 +249,7 @@
         "query": {
           "queryType": "get-clusters"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,

--- a/dashboards/px_namespace.json
+++ b/dashboards/px_namespace.json
@@ -400,7 +400,7 @@
         "query": {
           "queryType": "get-clusters"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -421,7 +421,7 @@
           },
           "queryType": "get-namespaces"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,

--- a/dashboards/px_node.json
+++ b/dashboards/px_node.json
@@ -1100,7 +1100,7 @@
         "query": {
           "queryType": "get-clusters"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -1121,7 +1121,7 @@
           },
           "queryType": "get-nodes"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,

--- a/dashboards/px_pod.json
+++ b/dashboards/px_pod.json
@@ -1380,7 +1380,7 @@
         "query": {
           "queryType": "get-clusters"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -1401,7 +1401,7 @@
           },
           "queryType": "get-pods"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,

--- a/dashboards/px_service.json
+++ b/dashboards/px_service.json
@@ -842,7 +842,7 @@
         "query": {
           "queryType": "get-clusters"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -863,7 +863,7 @@
           },
           "queryType": "get-services"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
@@ -872,7 +872,7 @@
     ]
   },
   "time": {
-    "from": "now-30m",
+    "from": "now-15m",
     "to": "now"
   },
   "timepicker": {},


### PR DESCRIPTION
In Grafana 7.5.* theres a bug where Grafana doesn't update dashboard variables when the parent is updated. This PR allows for the manual variables update when clicking on "Refresh" button.

Signed-off-by: Taras Priadka <tpriadka@pixielabs.ai>
