### PR TITLE
API key and cluster ID string stripping

### DIFF
--- a/pkg/pixie_plugin.go
+++ b/pkg/pixie_plugin.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
@@ -70,6 +71,9 @@ func (td *PixieDatasource) QueryData(ctx context.Context, req *backend.QueryData
 
 // Creates Pixie API client using API key and cloud Address
 func createClient(ctx context.Context, apiKey string, cloudAddr string) (*pxapi.Client, error) {
+	// untrimmed apiKey string will cause an error when creating a client
+	apiKey = strings.TrimSpace(apiKey)
+
 	var client *pxapi.Client
 	var err error
 	// First, create a client connecting to Pixie Cloud.
@@ -168,6 +172,9 @@ func (td *PixieDatasource) query(ctx context.Context, query backend.DataQuery,
 	if len(qm.QueryBody.ClusterID) != 0 {
 		clusterID = qm.QueryBody.ClusterID
 	}
+
+	// untrimmed clusterID string will cause an error when creating a vizier client
+	clusterID = strings.TrimSpace(clusterID)
 
 	if qm.QueryType != GetClusters && (len(qm.QueryBody.ClusterID) == 0 && clusterID == "") {
 		return nil, fmt.Errorf("no clusterID present in the request or default clusterID configured. Please set `pixieCluster` dashboard variable to `Pixie Datasource`->`Clusters`")

--- a/src/config_editor.tsx
+++ b/src/config_editor.tsx
@@ -35,7 +35,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
       ...options,
       secureJsonData: {
         ...options?.secureJsonData,
-        apiKey: event.target.value.trim(),
+        apiKey: event.target.value,
       },
     });
   };
@@ -47,7 +47,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
       ...options,
       secureJsonData: {
         ...options?.secureJsonData,
-        clusterId: event.target.value.trim(),
+        clusterId: event.target.value,
       },
     });
   };

--- a/src/config_editor.tsx
+++ b/src/config_editor.tsx
@@ -35,7 +35,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
       ...options,
       secureJsonData: {
         ...options?.secureJsonData,
-        apiKey: event.target.value,
+        apiKey: event.target.value.trim(),
       },
     });
   };
@@ -47,7 +47,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
       ...options,
       secureJsonData: {
         ...options?.secureJsonData,
-        clusterId: event.target.value,
+        clusterId: event.target.value.trim(),
       },
     });
   };
@@ -139,7 +139,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
             <SecretFormField
               isConfigured={(secureJsonFields && secureJsonFields.clusterId) as boolean}
               value={secureJsonData.clusterId || ''}
-              label="Cluster ID"
+              label="Default Cluster ID"
               placeholder="Default Cluster ID"
               labelWidth={20}
               inputWidth={20}


### PR DESCRIPTION
Users usually copy api key and cluster id from `work.pixie.ai` but sometimes that copy includes whitespace such as tabs or new lines.

Signed-off-by: Taras Priadka <tpriadka@pixielabs.ai>