### PR TITLE
Add `__requires` field to dashboard json files.

### DIFF
--- a/dashboards/README.md
+++ b/dashboards/README.md
@@ -1,0 +1,3 @@
+## Pixie Grafana Dashboards
+
+These Pixie dashboards are available in the [Grafana dashboard marketplace](https://grafana.com/grafana/dashboards/). You can also manually [import a dashboard](https://grafana.com/docs/grafana/v9.0/dashboards/export-import/#import-dashboard).

--- a/dashboards/px_cluster.json
+++ b/dashboards/px_cluster.json
@@ -9,6 +9,26 @@
       "pluginName": "Pixie Grafana Datasource Plugin"
     }
   ],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "nodeGraph",
+      "name": "Node Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "pixie-pixie-datasource",
+      "name": "Pixie Grafana Datasource Plugin",
+      "version": "0.0.9"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {

--- a/dashboards/px_cluster.json
+++ b/dashboards/px_cluster.json
@@ -755,7 +755,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "px/cluster",
+  "title": "Pixie K8s Cluster Overview",
+  "description": "Dashboard includes a service map of the HTTP traffic between the services in your cluster, along with the latency, error rate, and throughput per service. It also lists the nodes, namespaces and pods available in your cluster. To learn how to monitor service performance and infrastructure health using Pixie, see https://docs.px.dev/tutorials/pixie-101/service-performance/",
   "uid": "JMSOCJj7k",
   "version": 1,
   "weekStart": ""

--- a/dashboards/px_http_data.json
+++ b/dashboards/px_http_data.json
@@ -336,7 +336,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "px/http_data",
+  "title": "Pixie HTTP Traces",
+  "description": "Dashboard includes a table of the most recent full-body HTTP messages in your cluster. For more info about request tracing using Pixie, see https://docs.px.dev/tutorials/pixie-101/request-tracing",
   "uid": "HDxrIyjnz",
   "version": 1,
   "weekStart": ""

--- a/dashboards/px_http_data.json
+++ b/dashboards/px_http_data.json
@@ -9,6 +9,20 @@
       "pluginName": "Pixie Grafana Datasource Plugin"
     }
   ],
+  "__requires": [
+    {
+      "type": "datasource",
+      "id": "pixie-pixie-datasource",
+      "name": "Pixie Grafana Datasource Plugin",
+      "version": "0.0.9"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {

--- a/dashboards/px_namespace.json
+++ b/dashboards/px_namespace.json
@@ -9,6 +9,26 @@
       "pluginName": "Pixie Grafana Datasource Plugin"
     }
   ],
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "nodeGraph",
+      "name": "Node Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "pixie-pixie-datasource",
+      "name": "Pixie Grafana Datasource Plugin",
+      "version": "0.0.9"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {

--- a/dashboards/px_namespace.json
+++ b/dashboards/px_namespace.json
@@ -455,7 +455,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "px/namespace",
+  "title": "Pixie Namespace Overview",
+  "description": "Dashboard includes a service map of the HTTP traffic between the services in the selected namspace, along with the latency, error rate, and throughput per service. It also lists pods available in the namespace. To learn how to monitor service performance and infrastructure health using Pixie, see https://docs.px.dev/tutorials/pixie-101/service-performance/",
   "uid": "F6XZR_j7k",
   "version": 1,
   "weekStart": ""

--- a/dashboards/px_node.json
+++ b/dashboards/px_node.json
@@ -1193,8 +1193,10 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "px/node",
+  "title": "Pixie Node Overview",
+  "description": "Dashboard shows the pods on the selected node along with their CPU usage, memory consumption, and network traffic stats. To learn how to monitor infrastructure health using Pixie, see https://docs.px.dev/tutorials/pixie-101/infra-health/",
   "uid": "tcpoz_jnz",
   "version": 1,
   "weekStart": ""
 }
+

--- a/dashboards/px_node.json
+++ b/dashboards/px_node.json
@@ -9,6 +9,26 @@
       "pluginName": "Pixie Grafana Datasource Plugin"
     }
   ],
+  "__requires": [
+    {
+      "type": "datasource",
+      "id": "pixie-pixie-datasource",
+      "name": "Pixie Grafana Datasource Plugin",
+      "version": "0.0.9"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {

--- a/dashboards/px_pod.json
+++ b/dashboards/px_pod.json
@@ -1435,7 +1435,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "px/pod",
+  "title": "Pixie Pod Overview",
+  "description": "Dashboard shows an overview of the specified pod, including high-level HTTP application metrics, and resource usage. To learn how to monitor infrastructure health using Pixie, see https://docs.px.dev/tutorials/pixie-101/infra-health/",
   "uid": "_t3foxCnz",
   "version": 1,
   "weekStart": ""

--- a/dashboards/px_pod.json
+++ b/dashboards/px_pod.json
@@ -9,6 +9,26 @@
       "pluginName": "Pixie Grafana Datasource Plugin"
     }
   ],
+  "__requires": [
+    {
+      "type": "datasource",
+      "id": "pixie-pixie-datasource",
+      "name": "Pixie Grafana Datasource Plugin",
+      "version": "0.0.9"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {

--- a/dashboards/px_service.json
+++ b/dashboards/px_service.json
@@ -897,7 +897,8 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "px/service",
+  "title": "Pixie Service Overview",
+  "description": "Dashboard shows latency, error, and throughput over time for all HTTP requests for the selected service. It also includes a sample of slow requests to the service. To learn how to monitor service performance using Pixie, see https://docs.px.dev/tutorials/pixie-101/service-performance/",
   "uid": "qhHtFyCnk",
   "version": 1,
   "weekStart": ""

--- a/dashboards/px_service.json
+++ b/dashboards/px_service.json
@@ -9,6 +9,26 @@
       "pluginName": "Pixie Grafana Datasource Plugin"
     }
   ],
+  "__requires": [
+    {
+      "type": "datasource",
+      "id": "pixie-pixie-datasource",
+      "name": "Pixie Grafana Datasource Plugin",
+      "version": "0.0.9"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {


### PR DESCRIPTION
We want to make Pixie's dashboards publicly available on [Grafana's dashboard marketplace](https://grafana.com/grafana/dashboards/). The "__requires" field is required otherwise the upload fails: 
![image](https://user-images.githubusercontent.com/66266496/189452558-c1489c32-f078-4f63-9593-03cb5f0013b1.png)

Signed-off-by: Hannah Troisi <htroisi@pixielabs.ai>