### PR TITLE
Update config editor placeholder to reflect default Pixie cloud experience

### DIFF
--- a/src/config_editor.tsx
+++ b/src/config_editor.tsx
@@ -153,8 +153,8 @@ export class ConfigEditor extends PureComponent<Props, State> {
           <div className="gf-form">
             <FormField
               value={secureJsonData.cloudAddr || ''}
-              label="Pixie Cloud address (if not using withpixie.ai)"
-              placeholder="withpixie.ai:443"
+              label="Pixie Cloud address (if not using getcosmic.ai)"
+              placeholder="getcosmic.ai:443"
               labelWidth={20}
               inputWidth={20}
               onReset={this.onResetCloudAddr}


### PR DESCRIPTION
In https://github.com/pixie-io/pixie/pull/1991, the `px` cli was reinstated with a default cloud address. This was in response to feedback from users that the cloud agnostic version was confusing. This PR aligns the Grafana data source with the current cli behavior, which is to use the alphabetically first Pixie cloud vendor.

This will prevent situations like https://github.com/pixie-io/grafana-plugin/issues/100#issuecomment-2472240466.