### PR TITLE
Enable alerting for Pixie datasource

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -5,6 +5,7 @@
   "id": "pixie-pixie-datasource",
   "metrics": true,
   "backend": true,
+  "alerting": true,
   "executable": "gpx-pixie-pixie-datasource-plugin",
   "info": {
     "description": "Pixie's Grafana Datasource Plugin",


### PR DESCRIPTION
This closes #99

## Testing done
- Compiled plugin and set up datasource on local Grafana. Verified that an alert works and can create a Pagerduty incident
![Screen Shot 2024-11-17 at 2 39 39 PM](https://github.com/user-attachments/assets/ac3ab385-5db7-43b1-8123-f9e8a288185a)
