### PR TITLE
Store cloudAddr in unencrypted JSON data. Simplify logic for updating and resetting plugin settings

### DIFF
--- a/src/config_editor.tsx
+++ b/src/config_editor.tsx
@@ -16,9 +16,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { ChangeEvent, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
 import { LegacyForms } from '@grafana/ui';
-import { DataSourcePluginOptionsEditorProps } from '@grafana/data';
+import {
+    DataSourcePluginOptionsEditorProps,
+    onUpdateDatasourceJsonDataOption,
+    onUpdateDatasourceSecureJsonDataOption,
+    updateDatasourcePluginResetOption,
+} from '@grafana/data';
 import { PixieDataSourceOptions, PixieSecureDataSourceOptions } from './types';
 
 const { FormField, SecretFormField } = LegacyForms;
@@ -28,94 +33,19 @@ interface Props extends DataSourcePluginOptionsEditorProps<PixieDataSourceOption
 interface State {}
 
 export class ConfigEditor extends PureComponent<Props, State> {
-  onAPIKeyChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const { onOptionsChange, options } = this.props;
-
-    onOptionsChange({
-      ...options,
-      secureJsonData: {
-        ...options?.secureJsonData,
-        apiKey: event.target.value,
-      },
-    });
-  };
-
-  onClusterIdChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const { onOptionsChange, options } = this.props;
-
-    onOptionsChange({
-      ...options,
-      secureJsonData: {
-        ...options?.secureJsonData,
-        clusterId: event.target.value,
-      },
-    });
-  };
-
-  onCloudAddrChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const { onOptionsChange, options } = this.props;
-
-    onOptionsChange({
-      ...options,
-      secureJsonData: {
-        ...options?.secureJsonData,
-        cloudAddr: event.target.value,
-      },
-    });
-  };
-
   onResetAPIKey = () => {
-    const { onOptionsChange, options } = this.props;
-
-    onOptionsChange({
-      ...options,
-      secureJsonFields: {
-        ...options.secureJsonFields,
-        apiKey: false,
-      },
-      secureJsonData: {
-        ...options.secureJsonData,
-        apiKey: '',
-      },
-    });
+    updateDatasourcePluginResetOption(this.props, 'apiKey');
   };
 
   onResetClusterId = () => {
-    const { onOptionsChange, options } = this.props;
-
-    onOptionsChange({
-      ...options,
-      secureJsonFields: {
-        ...options.secureJsonFields,
-        clusterId: false,
-      },
-      secureJsonData: {
-        ...options.secureJsonData,
-        clusterId: '',
-      },
-    });
-  };
-
-  onResetCloudAddr = () => {
-    const { onOptionsChange, options } = this.props;
-
-    onOptionsChange({
-      ...options,
-      secureJsonFields: {
-        ...options.secureJsonFields,
-        cloudAddr: false,
-      },
-      secureJsonData: {
-        ...options.secureJsonData,
-        cloudAddr: '',
-      },
-    });
+    updateDatasourcePluginResetOption(this.props, 'clusterId');
   };
 
   render() {
     const { options } = this.props;
     const { secureJsonFields } = options;
     const secureJsonData = (options.secureJsonData || {}) as PixieSecureDataSourceOptions;
+    const jsonData = (options.jsonData || {}) as PixieDataSourceOptions;
 
     return (
       <div className="gf-form-group">
@@ -129,7 +59,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
               labelWidth={20}
               inputWidth={20}
               onReset={this.onResetAPIKey}
-              onChange={this.onAPIKeyChange}
+              onChange={onUpdateDatasourceSecureJsonDataOption(this.props, 'apiKey')}
             />
           </div>
         </div>
@@ -144,7 +74,7 @@ export class ConfigEditor extends PureComponent<Props, State> {
               labelWidth={20}
               inputWidth={20}
               onReset={this.onResetClusterId}
-              onChange={this.onClusterIdChange}
+              onChange={onUpdateDatasourceSecureJsonDataOption(this.props, 'clusterId')}
             />
           </div>
         </div>
@@ -152,13 +82,12 @@ export class ConfigEditor extends PureComponent<Props, State> {
         <div className="gf-form-inline">
           <div className="gf-form">
             <FormField
-              value={secureJsonData.cloudAddr || ''}
-              label="Pixie Cloud address (if not using withpixie.ai)"
-              placeholder="withpixie.ai:443"
+              value={jsonData.cloudAddr || ''}
+              label="Pixie Cloud address (if not using getcosmic.ai)"
+              placeholder="getcosmic.ai:443"
               labelWidth={20}
               inputWidth={20}
-              onReset={this.onResetCloudAddr}
-              onChange={this.onCloudAddrChange}
+              onChange={onUpdateDatasourceJsonDataOption(this.props, 'cloudAddr')}
             />
           </div>
         </div>

--- a/src/config_editor.tsx
+++ b/src/config_editor.tsx
@@ -19,10 +19,10 @@
 import React, { PureComponent } from 'react';
 import { LegacyForms } from '@grafana/ui';
 import {
-    DataSourcePluginOptionsEditorProps,
-    onUpdateDatasourceJsonDataOption,
-    onUpdateDatasourceSecureJsonDataOption,
-    updateDatasourcePluginResetOption,
+  DataSourcePluginOptionsEditorProps,
+  onUpdateDatasourceJsonDataOption,
+  onUpdateDatasourceSecureJsonDataOption,
+  updateDatasourcePluginResetOption,
 } from '@grafana/data';
 import { PixieDataSourceOptions, PixieSecureDataSourceOptions } from './types';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,13 +69,14 @@ export const defaultQuery: Partial<PixieDataQuery> = {
   },
 };
 
-export interface PixieDataSourceOptions extends DataSourceJsonData {}
+export interface PixieDataSourceOptions extends DataSourceJsonData {
+  // Address of Pixie cloud.
+  cloudAddr?: string;
+}
 
 export interface PixieSecureDataSourceOptions {
   // Pixie API key.
   apiKey?: string;
-  // Address of Pixie cloud.
-  cloudAddr?: string;
   // ID of the Pixie cluster to query.
   clusterId?: string;
 }


### PR DESCRIPTION
Summary: Store cloudAddr in unencrypted JSON data. Simplify logic for updating and resetting plugin settings

This addresses https://github.com/pixie-io/grafana-plugin/issues/100#issuecomment-2477989159. Before this change, all plugin settings were stored in `secureJsonData`. This means that all settings, even the non secret ones like `cloudAddr`, were all encrypted. This prevents the plugin from reading the currently saved `cloudAddr` back.

By storing the `cloudAddr` in `jsonData`, we can show the user the current value of the input field and prevent the confusion linked above. 

This change also simplifies the config editor component by leveraging the ` onUpdateDatasourceJsonDataOption`, `onUpdateDatasourceSecureJsonDataOption` and `updateDatasourcePluginResetOption` functions from Grafana's SDK.

Testing done: Built the plugin, loaded in a local Grafana and tested the following:
- [x]  Verified that queries work with a newly created data source
- [x] Verified that the plugin can read the currently configured `cloudAddr` setting
![grafana-datasource](https://github.com/user-attachments/assets/ccd7553e-96d3-4fc4-b7ac-b6f16301defa)
