### PR TITLE
Fix Grafana plugin release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,10 +109,10 @@ jobs:
       - name: Lint plugin
         run: |
           git clone --branch v0.7.1 --depth 1 https://github.com/grafana/plugin-validator
-          pushd ./plugin-validator/pkg/cmd/plugincheck
+          pushd ./plugin-validator/pkg/cmd/plugincheck2
           go install
           popd
-          plugincheck ${{ steps.metadata.outputs.archive }}
+          plugincheck2 ${{ steps.metadata.outputs.archive }}
       - name: Create release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-
     steps:
       - uses: actions/checkout@v2
 
@@ -110,6 +109,9 @@ jobs:
           echo "::set-output name=checksum::$(cat ./${{ steps.metadata.outputs.archive-checksum }} | cut -d' ' -f1)"
       - name: Lint plugin
         run: |
+          # TODO(ddelnano): This should be removed once Go is upgraded to 1.21 or later
+          # This will also likely change when https://github.com/pixie-io/grafana-plugin/issues/106
+          # is resolved
           git clone --branch v0.7.1 --depth 1 https://github.com/grafana/plugin-validator
           pushd ./plugin-validator/pkg/cmd/plugincheck2
           go install
@@ -117,39 +119,14 @@ jobs:
           plugincheck2 ${{ steps.metadata.outputs.archive }}
       - name: Create release
         id: create_release
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
           body_path: ${{ steps.changelog.outputs.path }}
+          files: |
+            ${{ steps.metadata.outputs.archive }}
+            ${{ steps.metadata.outputs.archive-checksum }}
           draft: true
-
-      - name: Add plugin to release
-        id: upload-plugin-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./${{ steps.metadata.outputs.archive }}
-          asset_name: ${{ steps.metadata.outputs.archive }}
-          asset_content_type: application/zip
-
-      - name: Add checksum to release
-        id: upload-checksum-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./${{ steps.metadata.outputs.archive-checksum }}
-          asset_name: ${{ steps.metadata.outputs.archive-checksum }}
-          asset_content_type: text/plain
-
-      - name: Publish to Grafana.com
-        run: |
-          echo A draft release has been created for your plugin. Please review and publish it. Then submit your plugin to grafana.com/plugins by opening a PR to https://github.com/grafana/grafana-plugin-repository with the following entry:
-          echo
-          echo '{ "id": "${{ steps.metadata.outputs.plugin-id }}", "type": "${{ steps.metadata.outputs.plugin-type }}", "url": "https://github.com/${{ github.repository }}", "versions": [ { "version": "${{ steps.metadata.outputs.plugin-version }}", "commit": "${{ github.sha }}", "url": "https://github.com/${{ github.repository }}", "download": { "any": { "url": "https://github.com/${{ github.repository }}/releases/download/v${{ steps.metadata.outputs.plugin-version }}/${{ steps.metadata.outputs.archive }}", "md5": "${{ steps.package-plugin.outputs.checksum }}" } } } ] }' | jq .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
           echo "::set-output name=checksum::$(cat ./${{ steps.metadata.outputs.archive-checksum }} | cut -d' ' -f1)"
       - name: Lint plugin
         run: |
-          git clone --branch v0.6.2 --depth 1 https://github.com/grafana/plugin-validator
+          git clone --branch v0.7.1 --depth 1 https://github.com/grafana/plugin-validator
           pushd ./plugin-validator/pkg/cmd/plugincheck
           go install
           popd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
           echo "::set-output name=checksum::$(cat ./${{ steps.metadata.outputs.archive-checksum }} | cut -d' ' -f1)"
       - name: Lint plugin
         run: |
-          git clone https://github.com/grafana/plugin-validator
+          git clone --branch v0.6.2 --depth 1 https://github.com/grafana/plugin-validator
           pushd ./plugin-validator/pkg/cmd/plugincheck
           go install
           popd


### PR DESCRIPTION
Fix Grafana plugin release job

When I tried to release the v0.10.0 version, I was unable to since the release job failed. This job will likely need more changes (see https://github.com/pixie-io/grafana-plugin/issues/106), but this will unblock publishing the v0.10.0 release.

Testing done:
- [x] [Release job](https://github.com/pixie-io/grafana-plugin/actions/runs/12190445681) ran successfully on test tag [v0.10.0-test-release-job](https://github.com/pixie-io/grafana-plugin/releases/tag/untagged-dcc6327e3fef6c4e24ec)